### PR TITLE
Add `pgf` prefix to package name `calendar-ext`

### DIFF
--- a/doc/tikz-ext-manual-en-calendar.tex
+++ b/doc/tikz-ext-manual-en-calendar.tex
@@ -10,7 +10,7 @@
 
 \section{Calendar: Weeknumbers and more conditionals}
 \label{sec:calendar}
-\begin{texpackage}{calendar-ext}
+\begin{texpackage}{pgfcalendar-ext}
   This package adds week numbers and more conditionals to the \pgfname\space package |pgfcalendar|.
 %  (Despite the code example above, this package is not set up to work with Con\TeX t.)
   \inspiration{WeekNum-Q,CalCond-Q,CalFullWeek-Q}{WeekNum-A,CalCond-A,CalFullWeek-A}


### PR DESCRIPTION
Currently package `calendar-ext` is mentioned in documentation, but the provided package files are both with prefix `pgf`, `pgfcalendar-ext.{sty,tex}`.